### PR TITLE
Addition of NoSemanticObjectException and project source encoding and adjustes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>br.com.ivansalvadori</groupId>
+	<groupId>br.com.srs</groupId>
 	<artifactId>gson-ld</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
+
+	<properties>
+	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
 	<dependencies>
 

--- a/src/main/java/br/com/srs/gsonld/GsonLD.java
+++ b/src/main/java/br/com/srs/gsonld/GsonLD.java
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import br.com.srs.gsonld.exception.NoSemanticObjectException;
+
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.JsonLdOptions;
 import com.github.jsonldjava.core.JsonLdProcessor;
@@ -27,7 +29,6 @@ public class GsonLD {
     	if(src == null){
     		return NULL_OBJECT_JSON;
     	}
-
         JsonLdDocument jsonLdDocument;
         try {
             jsonLdDocument = serializeObject(src);
@@ -38,48 +39,47 @@ public class GsonLD {
     }
 
     private JsonLdDocument serializeObject(Object src) throws IllegalArgumentException, IllegalAccessException {
-        JsonLdDocument jsonLdDocument = new JsonLdDocument();
-        if (src.getClass().isAnnotationPresent(SemanticClass.class)) {
-            String objectSemanticType = src.getClass().getAnnotation(SemanticClass.class).value();
-            jsonLdDocument.addProperties("@type", objectSemanticType);
-
-            Field[] declaredFields = src.getClass().getDeclaredFields();
-            for (Field field : declaredFields) {
-            	if(Modifier.isStatic(field.getModifiers())){
-            		continue;
-            	}
-            	if(Modifier.isTransient(field.getModifiers())){
-            		continue;
-            	}
-                field.setAccessible(true);
-                if (!field.getType().isAnnotationPresent(SemanticClass.class)) {
-                    if (field.isAnnotationPresent(Id.class)) {
-                        jsonLdDocument.addProperties("@id", field.get(src));
-                    } else if (field.get(src) instanceof List<?>) {
-                        return serializeList(field.get(src), field.getName());
-                    } else {
-                        jsonLdDocument.addProperties(field.getName(), field.get(src));
-                    }
-                } else if (field.getType().isAnnotationPresent(SemanticClass.class)) {
-                    JsonLdDocument innerSemanticObject = serializeObject(field.get(src));
-                    // POG initiate
-                    innerSemanticObject.addProperties("@context", innerSemanticObject.getContext());
-                    // POG applied successfully
-                    jsonLdDocument.addProperties(field.getName(), innerSemanticObject.getProperties());
-                }
-                if (field.isAnnotationPresent(SemanticProperty.class)) {
-                    jsonLdDocument.addContext(field.getName(), field.getAnnotation(SemanticProperty.class).value());
-                }
-            }
-
-            return jsonLdDocument;
-        }
-
         if (src instanceof List<?>) {
-            return serializeList(src, "@graph");
+        	return serializeList(src, "@graph");
+        }
+        if(!src.getClass().isAnnotationPresent(SemanticClass.class)){
+        	throw new NoSemanticObjectException(src);
+        }
+        JsonLdDocument jsonLdDocument = new JsonLdDocument();
+        String objectSemanticType = src.getClass().getAnnotation(SemanticClass.class).value();
+        jsonLdDocument.addProperties("@type", objectSemanticType);
+
+        Field[] declaredFields = src.getClass().getDeclaredFields();
+        for (Field field : declaredFields) {
+        	if(Modifier.isStatic(field.getModifiers())){
+        		continue;
+        	}
+        	if(Modifier.isTransient(field.getModifiers())){
+        		continue;
+        	}
+            field.setAccessible(true);
+            boolean isSemanticClassAnnotationPresent = field.getType().isAnnotationPresent(SemanticClass.class);
+			if (!isSemanticClassAnnotationPresent) {
+                if (field.isAnnotationPresent(Id.class)) {
+                    jsonLdDocument.addProperties("@id", field.get(src));
+                } else if (field.get(src) instanceof List<?>) {
+                    return serializeList(field.get(src), field.getName());
+                } else {
+                    jsonLdDocument.addProperties(field.getName(), field.get(src));
+                }
+            } else if (isSemanticClassAnnotationPresent) {
+                JsonLdDocument innerSemanticObject = serializeObject(field.get(src));
+                // POG initiate
+                innerSemanticObject.addProperties("@context", innerSemanticObject.getContext());
+                // POG applied successfully
+                jsonLdDocument.addProperties(field.getName(), innerSemanticObject.getProperties());
+            }
+            if (field.isAnnotationPresent(SemanticProperty.class)) {
+                jsonLdDocument.addContext(field.getName(), field.getAnnotation(SemanticProperty.class).value());
+            }
         }
 
-        return null;
+        return jsonLdDocument;
     }
 
     private JsonLdDocument serializeList(Object src, String listName) throws IllegalAccessException {

--- a/src/main/java/br/com/srs/gsonld/GsonLD.java
+++ b/src/main/java/br/com/srs/gsonld/GsonLD.java
@@ -1,6 +1,5 @@
 package br.com.srs.gsonld;
 
-import java.beans.Transient;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/src/main/java/br/com/srs/gsonld/exception/NoSemanticObjectException.java
+++ b/src/main/java/br/com/srs/gsonld/exception/NoSemanticObjectException.java
@@ -1,0 +1,9 @@
+package br.com.srs.gsonld.exception;
+
+@SuppressWarnings("serial")
+public class NoSemanticObjectException extends RuntimeException{
+
+	public NoSemanticObjectException(Object o) {
+		super(String.format("Object class must be annotated with @SemanticClass. Class [%s]", o.getClass()));
+	}
+}

--- a/src/test/java/br/com/srs/gsonld/test/GsonLDTest.java
+++ b/src/test/java/br/com/srs/gsonld/test/GsonLDTest.java
@@ -2,16 +2,12 @@ package br.com.srs.gsonld.test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.Test;
 
 import br.com.srs.gsonld.GsonLD;
 
 import com.github.jsonldjava.core.JsonLdError;
-import com.github.jsonldjava.core.JsonLdOptions;
-import com.github.jsonldjava.core.JsonLdProcessor;
 import com.github.jsonldjava.utils.JsonUtils;
 
 public class GsonLDTest {
@@ -52,11 +48,7 @@ public class GsonLDTest {
     private String getSampleFileAsString(String filename) throws IOException, JsonLdError {
         InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(filename);
         Object jsonObject = JsonUtils.fromInputStream(inputStream);
-        Map<String, String> context = new HashMap<String, String>();
-        JsonLdOptions options = new JsonLdOptions();
-        Object compact = JsonLdProcessor.compact(jsonObject, context, options);
-        String jsonLD = JsonUtils.toPrettyString(jsonObject);
-        return jsonLD;
+        return JsonUtils.toPrettyString(jsonObject);
     }
 
 }

--- a/src/test/java/br/com/srs/gsonld/test/JsonLDTest.java
+++ b/src/test/java/br/com/srs/gsonld/test/JsonLDTest.java
@@ -43,9 +43,6 @@ public class JsonLDTest {
     public void deveReconhecerPropriedadesEnderecoCompleto() throws Exception {
         InputStream inputStream = classLoader.getResourceAsStream("JohnPlainProperties.jsonld");
         Object jsonObject = JsonUtils.fromInputStream(inputStream);
-        Map<String, String> context = new HashMap<String, String>();
-        JsonLdOptions options = new JsonLdOptions();
-        Object compact = JsonLdProcessor.compact(jsonObject, context, options);
         System.out.println(JsonUtils.toPrettyString(jsonObject));
 
     }

--- a/src/test/java/br/com/srs/gsonld/test/ObjectWithoutSemanticClassAnotationTest.java
+++ b/src/test/java/br/com/srs/gsonld/test/ObjectWithoutSemanticClassAnotationTest.java
@@ -1,0 +1,22 @@
+package br.com.srs.gsonld.test;
+
+import org.junit.Test;
+
+import br.com.srs.gsonld.GsonLD;
+import br.com.srs.gsonld.exception.NoSemanticObjectException;
+
+public class ObjectWithoutSemanticClassAnotationTest {
+	
+	private GsonLD gsonLD = new GsonLD();
+
+	static class TestWithPrivateField{
+		int integer = 0;
+		Byte b= 3;
+	}
+	
+	@Test(expected=NoSemanticObjectException.class)
+	public void serializeObjectWithStaticFields(){
+		gsonLD.toJsonLD(new TestWithPrivateField());
+	}
+
+}


### PR DESCRIPTION
Added exception (“NoSemanticObjectException”) that is thrown when the source object is not annotated with @SemanticClass.

Changed the groupId in pom.xml to “br.com.srs”

Added property “project.build.sourceEncoding” to define the project encoding to UTF-8
